### PR TITLE
Add functionality clear all complete items from the TODO list app.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,4 +9,5 @@ window.onload = () => {
   const controller = new Controller(new Model(), new View());
   controller.populateItems();
   controller.addNewItem();
+  controller.clearAllCompleted();
 };

--- a/src/modules/Controller.js
+++ b/src/modules/Controller.js
@@ -11,6 +11,7 @@ export default class {
     const updateDesriptionHander = this.handleDescriptionUpdate.bind(this);
     const deleteItemHandler = this.handleDeleteItem.bind(this);
     const markAsComplete = this.handleMarkAsComplete.bind(this);
+    const clearAllCompleted = this.handleMarkAsComplete.bind(this);
 
     const eventHandlers = [updateDesriptionHander, deleteItemHandler, markAsComplete];
     items.slice(0).reverse().map((item) => this.view.generateTemplate(item, eventHandlers));
@@ -32,7 +33,15 @@ export default class {
     this.model.deleteItem(index, this.populateItems.bind(this));
   }
 
+  handleClearAllCompleted(){
+    this.model.clearAllCompleted(this.populateItems.bind(this));
+  }
+
   addNewItem() {
     this.view.submitNewItem(this.handleNewItem.bind(this));
+  }
+
+  clearAllCompleted(){
+    this.view.clearAllCompleted(this.handleClearAllCompleted.bind(this));
   }
 }

--- a/src/modules/Controller.js
+++ b/src/modules/Controller.js
@@ -11,7 +11,6 @@ export default class {
     const updateDesriptionHander = this.handleDescriptionUpdate.bind(this);
     const deleteItemHandler = this.handleDeleteItem.bind(this);
     const markAsComplete = this.handleMarkAsComplete.bind(this);
-    const clearAllCompleted = this.handleMarkAsComplete.bind(this);
 
     const eventHandlers = [updateDesriptionHander, deleteItemHandler, markAsComplete];
     items.slice(0).reverse().map((item) => this.view.generateTemplate(item, eventHandlers));
@@ -33,7 +32,7 @@ export default class {
     this.model.deleteItem(index, this.populateItems.bind(this));
   }
 
-  handleClearAllCompleted(){
+  handleClearAllCompleted() {
     this.model.clearAllCompleted(this.populateItems.bind(this));
   }
 
@@ -41,7 +40,7 @@ export default class {
     this.view.submitNewItem(this.handleNewItem.bind(this));
   }
 
-  clearAllCompleted(){
+  clearAllCompleted() {
     this.view.clearAllCompleted(this.handleClearAllCompleted.bind(this));
   }
 }

--- a/src/modules/Model.js
+++ b/src/modules/Model.js
@@ -51,4 +51,19 @@ export default class {
     this.updateLocalStorage(this.items);
     populateItems();
   }
+
+  clearAllCompleted(populateItems){
+    let inComplete = this.items.filter((item)=>{
+      return !item.completed;
+    });
+
+    inComplete.map((item, i) => {
+      item.index = i;
+      return item.index;
+    });
+
+    this.items = inComplete;
+    this.updateLocalStorage(this.items);
+    populateItems();
+  }
 }

--- a/src/modules/Model.js
+++ b/src/modules/Model.js
@@ -52,10 +52,8 @@ export default class {
     populateItems();
   }
 
-  clearAllCompleted(populateItems){
-    let inComplete = this.items.filter((item)=>{
-      return !item.completed;
-    });
+  clearAllCompleted(populateItems) {
+    const inComplete = this.items.filter((item) => !item.completed);
 
     inComplete.map((item, i) => {
       item.index = i;

--- a/src/modules/View.js
+++ b/src/modules/View.js
@@ -12,8 +12,8 @@ export default class {
     }
   }
 
-  clearAllCompleted(handleClearAll){
-    this.clearAllButton.addEventListener('click', (e)=>{
+  clearAllCompleted(handleClearAll) {
+    this.clearAllButton.addEventListener('click', () => {
       handleClearAll();
     });
   }

--- a/src/modules/View.js
+++ b/src/modules/View.js
@@ -3,12 +3,19 @@ export default class {
     this.itemTemplate = document.querySelector('.todo-item-template');
     this.todoItems = document.querySelector('.todo-items');
     this.input = document.querySelector('.new-item');
+    this.clearAllButton = document.querySelector('.todo-clear-completed');
   }
 
   refreshDOM() {
     if (this.todoItems.hasChildNodes()) {
       this.todoItems.textContent = '';
     }
+  }
+
+  clearAllCompleted(handleClearAll){
+    this.clearAllButton.addEventListener('click', (e)=>{
+      handleClearAll();
+    });
   }
 
   generateTemplate(itemData, eventHandlers) {


### PR DESCRIPTION
## Proposed changes
The aim of this pull request is to add functionality clear all complete items from the TODO list app.

**The following features were added**
-   The user can click on an item's checkbox and that updates (`completed`: `true` / `false`).
-   Added event listener to the checkbox (`change`).
-   Updated items object's value for `completed` key upon user actions.
-   Implemented a function for the "Clear all completed" button (use `filter()` method).
-   Stored the updated array of items in local storage, so the user gets the correct list values after the page reloads.

## Type of change

-   New feature

## Checklist

-    [Linting tests](https://github.com/microverseinc/linters-config) pass locally with my changes
-    Used correct [GitHub flow](https://github.com/microverseinc/curriculum-transversal-skills/blob/main/git-github/articles/github_flow.md)
-    Documentation is done in a [professional way](https://github.com/microverseinc/curriculum-transversal-skills/blob/main/documentation/articles/professional_repo_rules.md)